### PR TITLE
Removed babel-loader for .tsx files and removed es2015 as target

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,16 +50,7 @@ module.exports = {
                 test: /\.tsx$/,
                 use: [
                     {
-                        loader: 'babel-loader',
-                        options: babelOptions
-                    },
-                    {
                         loader: 'ts-loader',
-                        options: {
-                            compilerOptions: {
-                                target: 'es2015'
-                            }
-                        }
                     }
                 ],
                 exclude: excludes


### PR DESCRIPTION
There was a bug in one of our projects with the current default compilation for **.tsx**-Files:
Due to the explicit target setting of *es2015*, it compiled to **.js**-Files with *es2015* Features like arrow-functions. This then caused several errors on minification with uglify as it does not understand *es2015*.

There are more reasons to **not** have a compiler chain from *es2015* -> *babel* for **.tsx** files:
1) Since the *ts-loader* can compile *.tsx*-Files from out of the box, the loader-chain with babel is an unnecessary duplication
2) Settings from the **tsconfig.json** Files are overwritten
3) The normal **.ts** Files are compiled differently from **.tsx** Files - but they should be treated all the same.
